### PR TITLE
RelayServer.cs: security fix: do not forward traffic from unknown sou…

### DIFF
--- a/BeatTogether.DedicatedServer.Kernel/Implementations/RelayServer.cs
+++ b/BeatTogether.DedicatedServer.Kernel/Implementations/RelayServer.cs
@@ -70,7 +70,7 @@ namespace BeatTogether.DedicatedServer.Kernel.Implementations
                 );
                 SendAsync(_sourceEndPoint, buffer);
             }
-            else
+            else if (endPoint.Equals(_sourceEndPoint))
             {
                 _logger.Verbose(
                     "Routing message from " +
@@ -78,6 +78,8 @@ namespace BeatTogether.DedicatedServer.Kernel.Implementations
                     $"(Data='{BitConverter.ToString(buffer.ToArray())}')."
                 );
                 SendAsync(_targetEndPoint, buffer);
+            } else
+            {
             }
 
             WaitForInactivityTimeout();


### PR DESCRIPTION
…rces to the target address

The origin of a UDP packet should always be verified and all packages that have not been received
from the target or the source address should be discarded.

Reason: As port numbers are given out as increasing numbers, lower port numbers are easy to
guess. An attacker could use an open port to flood a target address this way. As all traffic
will be routed to a valid remote address pair, it will also pass already opened ports on the
firewall on the target.

Thus, traffic not originated by any leg of the transmission, should be discarded.