### PR TITLE
RelayServer.cs: security fix: do not forward traffic from unknown sou…

### DIFF
--- a/BeatTogether.DedicatedServer.Kernel/Implementations/DedicatedServerService.cs
+++ b/BeatTogether.DedicatedServer.Kernel/Implementations/DedicatedServerService.cs
@@ -42,7 +42,19 @@ namespace BeatTogether.DedicatedServer.Kernel.Implementations
                     Error = GetAvailableRelayServerResponse.ErrorCode.NoAvailableRelayServers
                 });
             }
-            relayServer.Start();
+            if (!relayServer.Start())
+            {
+                _logger.Warning(
+                    "Failed to start UDP relay server for "+
+                    $"(SourceEndPoint='{request.SourceEndPoint}', " +
+                    $"TargetEndPoint='{request.TargetEndPoint}')."
+                );
+                return Task.FromResult(new GetAvailableRelayServerResponse()
+                {
+                    // TODO: should rarely happen, but a more specific error might be good
+                    Error = GetAvailableRelayServerResponse.ErrorCode.NoAvailableRelayServers
+                });
+            }
             return Task.FromResult(new GetAvailableRelayServerResponse()
             {
                 RemoteEndPoint = $"{_configuration.HostName}:{relayServer.Endpoint.Port}"

--- a/BeatTogether.DedicatedServer.Kernel/Implementations/RelayServer.cs
+++ b/BeatTogether.DedicatedServer.Kernel/Implementations/RelayServer.cs
@@ -70,7 +70,7 @@ namespace BeatTogether.DedicatedServer.Kernel.Implementations
                 );
                 SendAsync(_sourceEndPoint, buffer);
             }
-            else
+            else if (endPoint.Equals(_sourceEndPoint))
             {
                 _logger.Verbose(
                     "Routing message from " +


### PR DESCRIPTION
…rces to the target address

The origin of a UDP packet should always be verified and all packages that have not been received
from the target or the source address should be discarded.

Reason: As port numbers are given out as increasing numbers, lower port numbers are easy to
guess. An attacker could use an open port to flood a target address this way. As all traffic
will be routed to a valid remote address pair, it will also pass already opened ports on the
firewall on the target.

Thus, traffic not originated by any leg of the transmission, should be discarded.