### PR TITLE
DedicatedServerService: honor result code of relayServer.Start()

### DIFF
--- a/BeatTogether.DedicatedServer.Kernel/Implementations/DedicatedServerService.cs
+++ b/BeatTogether.DedicatedServer.Kernel/Implementations/DedicatedServerService.cs
@@ -42,7 +42,19 @@ namespace BeatTogether.DedicatedServer.Kernel.Implementations
                     Error = GetAvailableRelayServerResponse.ErrorCode.NoAvailableRelayServers
                 });
             }
-            relayServer.Start();
+            if (!relayServer.Start())
+            {
+                _logger.Warning(
+                    "Failed to start UDP relay server for "+
+                    $"(SourceEndPoint='{request.SourceEndPoint}', " +
+                    $"TargetEndPoint='{request.TargetEndPoint}')."
+                );
+                return Task.FromResult(new GetAvailableRelayServerResponse()
+                {
+                    // TODO: should rarely happen, but a more specific error might be good
+                    Error = GetAvailableRelayServerResponse.ErrorCode.NoAvailableRelayServers
+                });
+            }
             return Task.FromResult(new GetAvailableRelayServerResponse()
             {
                 RemoteEndPoint = $"{_configuration.HostName}:{relayServer.Endpoint.Port}"


### PR DESCRIPTION
The method can return false under several circumstances, but the relay server
would just return as if the socket has been successfully created.

The MasterServer would believe, that the socket exists resulting in issues that
can be painful to debug. Reasons for a failure here can be sockets that are
used by other applications or no properly closed connections from a previous
attempt.

It might be even better to try a different port instead, but that should at least
give some information about, if this issue happens at all.